### PR TITLE
@react-native-menu/menu+patch

### DIFF
--- a/.yarn/patches/@react-native-menu-menu-npm-1.2.3-182506938b.patch
+++ b/.yarn/patches/@react-native-menu-menu-npm-1.2.3-182506938b.patch
@@ -1,0 +1,18 @@
+diff --git a/package.json b/package.json
+index 60fc95c18470f83524869f5c625dfb7b9eb2f79d..b24a3a93d6ac7e73cb940cb43b6168082f497d64 100644
+--- a/package.json
++++ b/package.json
+@@ -110,7 +110,12 @@
+   "codegenConfig": {
+     "name": "RNMenuViewSpec",
+     "type": "components",
+-    "jsSrcsDir": "src"
++    "jsSrcsDir": "src",
++    "ios": {
++      "componentProvider": {
++        "MenuView": "MenuView"
++      }
++    }
+   },
+   "packageManager": "yarn@4.1.1"
+ }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@react-native-menu/menu": "1.2.3",
+    "@react-native-menu/menu": "patch:@react-native-menu/menu@npm%3A1.2.3#~/.yarn/patches/@react-native-menu-menu-npm-1.2.3-182506938b.patch",
     "@react-native/new-app-screen": "0.80.1",
     "react": "19.1.0",
     "react-native": "0.80.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2134,6 +2134,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native-menu/menu@patch:@react-native-menu/menu@npm%3A1.2.3#~/.yarn/patches/@react-native-menu-menu-npm-1.2.3-182506938b.patch":
+  version: 1.2.3
+  resolution: "@react-native-menu/menu@patch:@react-native-menu/menu@npm%3A1.2.3#~/.yarn/patches/@react-native-menu-menu-npm-1.2.3-182506938b.patch::version=1.2.3&hash=a9d1fe"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10c0/fed638185ff276548dc56ad68b6b7da339f25f9051931712eb063b96a573227dcc261bb69d29b344adc70893b32b58d33e6e6ef25b9caeac366b063865cb9c78
+  languageName: node
+  linkType: hard
+
 "@react-native/assets-registry@npm:0.80.1":
   version: 0.80.1
   resolution: "@react-native/assets-registry@npm:0.80.1"
@@ -2794,7 +2804,7 @@ __metadata:
     "@react-native-community/cli": "npm:19.0.0"
     "@react-native-community/cli-platform-android": "npm:19.0.0"
     "@react-native-community/cli-platform-ios": "npm:19.0.0"
-    "@react-native-menu/menu": "npm:1.2.3"
+    "@react-native-menu/menu": "patch:@react-native-menu/menu@npm%3A1.2.3#~/.yarn/patches/@react-native-menu-menu-npm-1.2.3-182506938b.patch"
     "@react-native/babel-preset": "npm:0.80.1"
     "@react-native/eslint-config": "npm:0.80.1"
     "@react-native/metro-config": "npm:0.80.1"


### PR DESCRIPTION
iOS no longer crashed but preview is gone:

https://github.com/user-attachments/assets/d64967c1-39ac-4c41-b37f-0f119319cd55

